### PR TITLE
Footer social media icons now link to correct URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,10 +218,12 @@
             <div class="footer-bottom">
                 <p>&copy; 2023 FoodExpress. All rights reserved.</p>
                 <div class="social-icons">
-                    <a href="#"><i class="fab fa-facebook"></i></a>
-                    <a href="#"><i class="fab fa-twitter"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
-                </div>
+  <a href="https://facebook.com" target="_blank"><i class="fab fa-facebook"></i></a>
+  <a href="https://twitter.com" target="_blank"><i class="fab fa-twitter"></i></a>
+  <a href="https://instagram.com" target="_blank"><i class="fab fa-instagram"></i></a>
+</div>
+
+
             </div>
         </div>
     </footer>


### PR DESCRIPTION
Updated <a> tags for Facebook, Instagram, and Twitter icons in the footer.

Earlier the icons were not linking to any profile (only #).

Now, clicking the icons correctly opens the respective social media pages in a new tab.